### PR TITLE
Added view code section in easing

### DIFF
--- a/app/easings/easing-usage.tsx
+++ b/app/easings/easing-usage.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { CodeIcon } from "lucide-react"
+
+import CodeBlock from "@/components/code-block"
+import CopyButton from "@/components/copy-button"
+import { Button } from "@/registry/default/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/registry/default/ui/dialog"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/registry/default/ui/tooltip"
+
+interface EasingUsageProps {
+  easing: {
+    name: string
+    points: number[]
+  }
+  duration: number
+}
+
+export default function EasingUsage({ easing, duration }: EasingUsageProps) {
+  const baseCode = `<div class="transition ease-[cubic-bezier(${easing.points.join(",")})] duration-[${duration}ms] hover:scale-105">Content to animate</div>`
+  const usageCode = `<div 
+  class="transition 
+    ease-[cubic-bezier(${easing.points.join(",")})] 
+    duration-[${duration}ms]
+    hover:scale-100">
+  // Content to animate 
+</div>`
+
+  return (
+    <Dialog>
+      <TooltipProvider delayDuration={0}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <DialogTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-muted-foreground/80 hover:text-foreground h-7 transition-none hover:bg-transparent disabled:opacity-100"
+                  aria-label="View usage"
+                >
+                  <CodeIcon size={16} aria-hidden={true} />
+                </Button>
+              </DialogTrigger>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent className="text-muted-foreground px-2 py-1 text-xs">
+            View code
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <DialogContent className="sm:max-w-[700px]">
+        <DialogHeader>
+          <DialogTitle className="text-left">Usage</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <p className="text-muted-foreground text-sm">
+            Use this easing function in your Tailwind CSS classes:
+          </p>
+          <div className="relative">
+            <CodeBlock code={usageCode} lang="html" />
+            <CopyButton componentSource={baseCode} />
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/easings/easings.tsx
+++ b/app/easings/easings.tsx
@@ -14,6 +14,7 @@ import {
 import { Slider } from "@/registry/default/ui/slider"
 
 import CopyClass from "./copy-class"
+import EasingUsage from "./easing-usage"
 
 interface Easing {
   name: string
@@ -430,6 +431,8 @@ export default function Easings({ easings }: EasingsProps) {
               <CopyClass
                 value={`ease-[cubic-bezier(${easing.points.join(",")})]`}
               />
+
+              <EasingUsage easing={easing} duration={duration} />
             </div>
           </div>
         ))}


### PR DESCRIPTION
So, in the https://originui.com/easings page, it was hard to know how to use the classes in our project. So I have added a new view code section to view the usage with Tailwind classes.

<img width="423" height="404" alt="Screenshot 2025-09-19 at 16 45 03" src="https://github.com/user-attachments/assets/b2a18344-b559-44f3-ad11-5098ddff3c5a" />
<img width="903" height="516" alt="Screenshot 2025-09-19 at 16 43 48" src="https://github.com/user-attachments/assets/197c8f46-cf57-44ce-be97-3e2a43510d08" />
