### PR TITLE
fix: comp-62 displaying wrong code for textarea with hint component

### DIFF
--- a/apps/origin/public/r/comp-62.json
+++ b/apps/origin/public/r/comp-62.json
@@ -8,8 +8,8 @@
   ],
   "files": [
     {
-      "path": "registry/default/components/comp-63.tsx",
-      "content": "import { useId } from \"react\"\n\nimport { Label } from \"@/registry/default/ui/label\"\nimport { Textarea } from \"@/registry/default/ui/textarea\"\n\nexport default function Component() {\n  const id = useId()\n  return (\n    <div className=\"[--ring:var(--color-indigo-300)] *:not-first:mt-2 in-[.dark]:[--ring:var(--color-indigo-900)]\">\n      <Label htmlFor={id}>Textarea with colored border and ring</Label>\n      <Textarea id={id} placeholder=\"Leave a comment\" />\n    </div>\n  )\n}\n",
+      "path": "registry/default/components/comp-62.tsx",
+      "content": "import { useId } from \"react\"\n\nimport { Label } from \"@/registry/default/ui/label\"\nimport { Textarea } from \"@/registry/default/ui/textarea\"\n\nexport default function Component() {\n  const id = useId()\n  return (\n    <div className=\"*:not-first:mt-2\">\n      <div className=\"flex items-center justify-between gap-2\">\n        <Label htmlFor={id} className=\"leading-6\">\n          Textarea with hint\n        </Label>\n        <span className=\"text-sm text-muted-foreground\">Optional</span>\n      </div>\n      <Textarea id={id} placeholder=\"Leave a comment\" />\n    </div>\n  )\n}\n",
       "type": "registry:component"
     }
   ],

--- a/apps/origin/registry.json
+++ b/apps/origin/registry.json
@@ -1583,7 +1583,7 @@
       ],
       "files": [
         {
-          "path": "registry/default/components/comp-63.tsx",
+          "path": "registry/default/components/comp-62.tsx",
           "type": "registry:component"
         }
       ],


### PR DESCRIPTION
### summary
- fixed bug where comp-62 (Textarea with hint) was displaying the wrong code from comp-63 (Textarea with colored border and ring).

fixes: #427 

### Changes Made
- **registry.json**: Updated comp-62 to point to correct file `comp-62.tsx` instead of `comp-63.tsx`
- **public/r/comp-62.json**: Fixed file path and content to match the actual "Textarea with hint" component

### Result
- Now when viewing the "Textarea with hint" component, it correctly displays its own code with the hint text "Optional", while "Textarea with colored border and ring" displays its proper code as expected.