### PR TITLE
style: fix icon alignment on alert with only a long description

### DIFF
--- a/apps/ui/registry/default/ui/alert.tsx
+++ b/apps/ui/registry/default/ui/alert.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "relative grid w-full items-start gap-x-2 rounded-xl border bg-card px-3 py-2.5 text-sm text-card-foreground has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-2 has-[>svg]:has-data-[slot=alert-action]:grid-cols-[calc(var(--spacing)*4)_1fr_auto] [&>svg]:size-4 [&>svg]:self-center",
+  "relative grid w-full items-start gap-x-2 rounded-xl border bg-card px-3 py-2.5 text-sm text-card-foreground has-data-[slot=alert-action]:grid-cols-[1fr_auto] has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-2 has-[>svg]:has-data-[slot=alert-action]:grid-cols-[calc(var(--spacing)*4)_1fr_auto] [&>svg]:mt-0.5 [&>svg]:size-4",
   {
     variants: {
       variant: {


### PR DESCRIPTION
Before:

![CleanShot 2025-10-15 at 15 27 00@2x](https://github.com/user-attachments/assets/e96bdb33-cdeb-45ad-8257-a96acfbbac38)

After:

![CleanShot 2025-10-15 at 15 27 38@2x](https://github.com/user-attachments/assets/f3b1f586-459a-4f8f-a29d-3e4a491dd956)
