### PR TITLE
fix(table): prevent background bleeding outside rounded corners in Firefox

### DIFF
--- a/apps/ui/registry/default/ui/table.tsx
+++ b/apps/ui/registry/default/ui/table.tsx
@@ -38,7 +38,7 @@ function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
     <tbody
       data-slot="table-body"
       className={cn(
-        "relative before:pointer-events-none before:absolute before:inset-px before:rounded-[calc(var(--radius-xl)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] not-in-data-[slot=frame]:before:hidden in-data-[slot=frame]:rounded-xl in-data-[slot=frame]:shadow-xs dark:bg-clip-border dark:before:shadow-[0_-1px_--theme(--color-white/8%)] [&_tr:last-child]:border-0 in-data-[slot=frame]:*:[tr]:border-0 in-data-[slot=frame]:*:[tr]:bg-card in-data-[slot=frame]:*:[tr]:hover:bg-card in-data-[slot=frame]:*:[tr]:*:[td]:border-b in-data-[slot=frame]:*:[tr]:*:[td]:bg-clip-padding in-data-[slot=frame]:*:[tr]:first:*:[td]:first:rounded-ss-xl in-data-[slot=frame]:*:[tr]:*:[td]:first:border-s in-data-[slot=frame]:*:[tr]:first:*:[td]:border-t in-data-[slot=frame]:*:[tr]:last:*:[td]:last:rounded-ee-xl in-data-[slot=frame]:*:[tr]:*:[td]:last:border-e in-data-[slot=frame]:*:[tr]:first:*:[td]:last:rounded-se-xl in-data-[slot=frame]:*:[tr]:last:*:[td]:first:rounded-es-xl in-data-[slot=frame]:*:[tr]:hover:*:[td]:bg-muted/32",
+        "relative before:pointer-events-none before:absolute before:inset-px before:rounded-[calc(var(--radius-xl)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] not-in-data-[slot=frame]:before:hidden in-data-[slot=frame]:rounded-xl in-data-[slot=frame]:shadow-xs dark:bg-clip-border dark:before:shadow-[0_-1px_--theme(--color-white/8%)] [&_tr:last-child]:border-0 in-data-[slot=frame]:*:[tr]:border-0 in-data-[slot=frame]:*:[tr]:*:[td]:border-b in-data-[slot=frame]:*:[tr]:*:[td]:bg-card in-data-[slot=frame]:*:[tr]:*:[td]:bg-clip-padding in-data-[slot=frame]:*:[tr]:first:*:[td]:first:rounded-ss-xl in-data-[slot=frame]:*:[tr]:*:[td]:first:border-s in-data-[slot=frame]:*:[tr]:first:*:[td]:border-t in-data-[slot=frame]:*:[tr]:last:*:[td]:last:rounded-ee-xl in-data-[slot=frame]:*:[tr]:*:[td]:last:border-e in-data-[slot=frame]:*:[tr]:first:*:[td]:last:rounded-se-xl in-data-[slot=frame]:*:[tr]:last:*:[td]:first:rounded-es-xl in-data-[slot=frame]:*:[tr]:hover:*:[td]:bg-muted/32",
         className
       )}
       {...props}
@@ -64,7 +64,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "border-b transition-colors hover:bg-muted data-[state=selected]:bg-muted",
+        "border-b transition-colors hover:bg-muted in-data-[slot=frame]:hover:bg-transparent data-[state=selected]:bg-muted in-data-[slot=frame]:data-[state=selected]:bg-transparent",
         className
       )}
       {...props}


### PR DESCRIPTION
## Problem

The rounded corners applied to table cells at the edges in the table body (so top-left, top-right, bottom-left, and bottom-right) were not properly clipping the background color in **Firefox**. The cell background color was visible bleeding outside the rounded corners in both normal and hover states.

Notice the darker background here on the table cells in the corners:

<img width="1266" height="640" alt="Screenshot 2025-10-16 at 19 23 19" src="https://github.com/user-attachments/assets/6b2d4a1d-15f8-4c04-9a8d-2089f41a13e6" />

Here you can really see it:
<img width="432" height="304" alt="Screenshot 2025-10-16 at 19 24 09" src="https://github.com/user-attachments/assets/1931cbeb-75b8-4c09-a675-a6bf42794c6b" />

This issue only appeared in Firefox, Chrome was rendering correctly.

### Root Cause

The background colors were being applied to the `<tr>` elements via:
- `in-data-[slot=frame]:*:[tr]:bg-card`
- `in-data-[slot=frame]:*:[tr]:hover:bg-card`

Firefox (correctly) doesn't clip `<tr>` background colors to the `border-radius` applied to child `<td>` elements. The background of the row element extends beyond the rounded corners of its cells.

## Solution

Move background color styling from `<tr>` elements to `<td>` elements, where the `border-radius` is actually applied:

**In `TableBody`:**
- Changed `in-data-[slot=frame]:*:[tr]:bg-card` → `in-data-[slot=frame]:*:[tr]:*:[td]:bg-card`
- Kept `bg-clip-padding` on cells to ensure backgrounds respect borders
- Hover effect already applies to cells: `in-data-[slot=frame]:*:[tr]:hover:*:[td]:bg-muted/32`

**In `TableRow`:**
- Added `in-data-[slot=frame]:hover:bg-transparent` to prevent row hover from interfering
- Added `in-data-[slot=frame]:data-[state=selected]:bg-transparent` for selected state

<img width="1276" height="642" alt="Screenshot 2025-10-16 at 19 25 50" src="https://github.com/user-attachments/assets/10f9e781-347c-4294-be52-1092ab24cd5e" />

This ensures the background is rendered at the same level where clipping occurs, allowing Firefox to properly clip the background to the rounded corners.

## Testing
- I manually checked that tables in other scenarios were not affected by this change, Chrome or Firefox.
- I checked every other components of the library to see if Firefox wanted to mess up with us, but haven't found anything!

PS: It's really a beautiful component library, this frame table looks amazing.
