### PR TITLE
fix(particle-display): use correct yarn command syntax

### DIFF
--- a/apps/ui/app/particles/particle-display.tsx
+++ b/apps/ui/app/particles/particle-display.tsx
@@ -87,7 +87,7 @@ export async function ParticleDisplay({
                   <figure data-rehype-pretty-code-figure>
                     <CodeBlockCommand
                       __npm__={`npx shadcn@latest add ${cossuiUrl}/r/${name}.json`}
-                      __yarn__={`yarn shadcn@latest add ${cossuiUrl}/r/${name}.json`}
+                      __yarn__={`yarn dlx shadcn@latest add ${cossuiUrl}/r/${name}.json`}
                       __pnpm__={`pnpm dlx shadcn@latest add ${cossuiUrl}/r/${name}.json`}
                       __bun__={`bunx --bun shadcn@latest add ${cossuiUrl}/r/${name}.json`}
                     />


### PR DESCRIPTION
## Problem

The [particle display installation command](https://coss.com/ui/particles) displays the wrong package manager for **Yarn**. When clicking on "View code", then selecting "yarn", it shows `npx install...` instead of `yarn install...`

<img width="743" height="157" alt="Screenshot 2025-10-17 at 16 57 49" src="https://github.com/user-attachments/assets/82fcae0d-281e-4626-ac9c-9bad112d8eec" />

### Root Cause

```tsx
<CodeBlockCommand
  __npm__={`npx shadcn@latest add ${cossuiUrl}/r/${name}.json`}
  __yarn__={`npx shadcn@latest add ${cossuiUrl}/r/${name}.json`} // This line is wrong
  __pnpm__={`pnpm dlx shadcn@latest add ${cossuiUrl}/r/${name}.json`}
  __bun__={`bunx --bun shadcn@latest add ${cossuiUrl}/r/${name}.json`}
/>
```

## Solution

<img width="743" height="157" alt="Screenshot 2025-10-17 at 17 03 39" src="https://github.com/user-attachments/assets/a87b9d15-be0e-4a1c-a18f-365c04cb2727" />

Using all my engineering expertise, I determined that replacing `npx` with `yarn` might make the Yarn command use Yarn.  
After several seconds of deliberation, I confirmed this was correct and implemented the fix.

I hope this PR helps!
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the particle display “View code” for Yarn to show the correct command, using yarn instead of npx. Prevents confusion when installing particles with Yarn.

- **Bug Fixes**
  - Changed CodeBlockCommand __yarn__ to use `yarn shadcn@latest add ...` instead of `npx`.

<!-- End of auto-generated description by cubic. -->

