### PR TITLE
Fix: Fix a import path typo in docs

### DIFF
--- a/apps/ui/content/docs/components/toast.mdx
+++ b/apps/ui/content/docs/components/toast.mdx
@@ -26,10 +26,10 @@ npx shadcn@latest add @coss/toast
 
 <span data-lib="base-ui">
 ```tsx title="app/layout.tsx"
-// [!code word:import { ToastProvider } from "@/rcomponents/ui/toast"]
+// [!code word:import { ToastProvider } from "@/components/ui/toast"]
 // [!code word:<ToastProvider>]
 // [!code word:</ToastProvider>]
-import { ToastProvider } from "@/rcomponents/ui/toast"
+import { ToastProvider } from "@/components/ui/toast"
 
 export default function RootLayout({ children }) {
   return (


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed an incorrect import path in the toast docs so the example works when copied. Updated the ToastProvider import from "@/rcomponents/ui/toast" to "@/components/ui/toast".

<!-- End of auto-generated description by cubic. -->

