### PR TITLE
fix(ui): fix copy to clipboard

### DIFF
--- a/apps/ui/app/docs/[[...slug]]/page.tsx
+++ b/apps/ui/app/docs/[[...slug]]/page.tsx
@@ -56,6 +56,7 @@ export default async function Page(props: {
   }
 
   const doc = page.data
+  const rawContent = await page.data.getText("raw");
   const MDX = doc.body
   const neighbours = await findNeighbour(source.pageTree, page.url)
 
@@ -97,7 +98,7 @@ export default async function Page(props: {
                       }
                     />
                   )}
-                  <DocsCopyPage page={`# ${doc.title}\n\n`} />
+                  <DocsCopyPage page={rawContent} />
                 </div>
               </div>
               <div className="w-full flex-1 *:data-[slot=alert]:first:mt-0">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the docs “Copy” button to copy the full page content. It no longer copies only the title.

- **Bug Fixes**
  - Retrieve rawContent with page.data.getText("raw") and pass it to DocsCopyPage.

<!-- End of auto-generated description by cubic. -->

