### PR TITLE
minor fix: capitalization in migration path text in index.mdx

### DIFF
--- a/apps/ui/content/docs/(root)/index.mdx
+++ b/apps/ui/content/docs/(root)/index.mdx
@@ -37,7 +37,7 @@ If you've used shadcn/ui, you'll feel right at home. The main difference is the 
 
 We chose Base UI for its robust, accessible, and unopinionated primitives. It handles the hard parts—like accessibility, keyboard navigation, and focus management—without imposing any styles. This gives us the freedom to create a design system that is both beautiful and flexible, and it gives you a solid foundation to build upon.
 
-If you're considering a move from a Radix-based library, we provide a clear migration path. Each of our components comes with detailed Comparing with Radix / shadcn to make the transition as smooth as possible.
+If you're considering a move from a Radix-based library, we provide a clear migration path. Each of our components comes with detailed comparing with Radix / shadcn to make the transition as smooth as possible.
 
 ## Primitives, Particles and Atoms
 


### PR DESCRIPTION
Corrected capitalization in the migration path description.