### PR TITLE
chore: install bun 1.3.1 as per package.json on vercel

### DIFF
--- a/apps/origin/vercel.json
+++ b/apps/origin/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "curl -fsSL https://bun.sh/install | bash -s -- \"bun-v1.3.1\" && ~/.bun/bin/bun install"
+}
+

--- a/apps/ui/vercel.json
+++ b/apps/ui/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "curl -fsSL https://bun.sh/install | bash -s -- \"bun-v1.3.1\" && ~/.bun/bin/bun install"
+}
+

--- a/apps/www/vercel.json
+++ b/apps/www/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "curl -fsSL https://bun.sh/install | bash -s -- \"bun-v1.3.1\" && ~/.bun/bin/bun install"
+}
+


### PR DESCRIPTION
# What does this PR do?

After upgrading the monorepo to use bun as package manager we noticed that deployments weren't working anymore. This is due to Vercel not providing an option to select a bun version and simply ships with an arbitrary version they chose. In this case we required the version to be > 1.3. Since we run everything with 1.3.1 but didn't want an auto-update breaking out Vercel deployments, we added a `vercel.json` to each app in order to specifically set the bun version used to install packages to 1.3.1.

# How to test

There is nothing to test locally. Build should pass on Vercel instead of failing due to not found module references.