### PR TITLE
docs: update licensing information

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -8,5 +8,6 @@ The following directory and their subdirectories are licensed under their origin
 
 ```
 apps/origin/
+apps/ui/
 ```
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Please see our [Contributing Guidelines](apps/ui/CONTRIBUTING.md) for more infor
 
 This repository uses a mixed licensing approach. The default license for this project is [AGPLv3.0](LICENSE).
 
-- **MIT**: The `apps/origin/` directory is licensed under its original MIT license
+- **MIT**: The `apps/origin/` and `apps/ui/` directories are licensed under its original MIT license
 - **AGPLv3**: All other directories are licensed under the GNU Affero General Public License v3.0
 
 For detailed information, see our [Licensing documentation](LICENSING.md).


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified mixed licensing: apps/ui is now explicitly listed as MIT-licensed alongside apps/origin. Updated README and LICENSING.md to reflect this.

<sup>Written for commit 380162f17c04fc2f9638164aaf8b5602dcf106f6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

