### PR TITLE
style: adjust header skeleton size

### DIFF
--- a/packages/ui/src/components/github-link.tsx
+++ b/packages/ui/src/components/github-link.tsx
@@ -17,7 +17,7 @@ export function GitHubLink() {
         <Link href={siteConfig.links.github} target="_blank" rel="noreferrer">
           <HugeiconsIcon icon={GithubIcon} className="size-4" strokeWidth={2} />
           <span className="max-sm:sr-only">
-            <React.Suspense fallback={<Skeleton className="h-4 w-8" />}>
+            <React.Suspense fallback={<Skeleton className="h-4 w-[25.5px]" />}>
               <StarsCount />
             </React.Suspense>
           </span>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Right-sized the header GitHub stars fallback skeleton from 32px (w-8) to 25.5px to match the star count width and reduce layout shift. Supports CUI-35 by aligning the header skeleton with COSS UI.

<sup>Written for commit d3023dfabdb61a9d1f0b32daaa654e984d4ed603. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

