### PR TITLE
docs: fix typos in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![coss.com](https://github.com/user-attachments/assets/56dfe7f7-85b7-44ee-b89a-1c30c5c4a156)
+
 <h3 align="center">coss.com (formerly Origin UI)</h3>
 <p align="center">The <strong>everything but AI</strong> company.</p>
 
@@ -127,7 +128,7 @@ Please see our [Contributing Guidelines](apps/ui/CONTRIBUTING.md) for more infor
 
 This repository uses a mixed licensing approach. The default license for this project is [AGPLv3.0](LICENSE).
 
-- **MIT**: The `apps/origin/` and `apps/ui/` directories are licensed under its original MIT license
+- **MIT**: The `apps/origin/` and `apps/ui/` directories are licensed under their original MIT license
 - **AGPLv3**: All other directories are licensed under the GNU Affero General Public License v3.0
 
 For detailed information, see our [Licensing documentation](LICENSING.md).
@@ -139,4 +140,4 @@ Special thanks to:
 - **[Tailwind CSS](https://tailwindcss.com/)** - For the utility-first CSS framework that powers our design system
 - **[Base UI](https://base-ui.com/)** - For providing the robust, accessible primitives that form the foundation of our components
 - **[shadcn/ui](https://ui.shadcn.com/)** - For inspiring our copy-paste approach and component philosophy
-- **[Fumadocs](https://fumadocs.dev/)** - For providing the documentation framework that powers our component docs 
+- **[Fumadocs](https://fumadocs.dev/)** - For providing the documentation framework that powers our component docs

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -56,7 +56,7 @@ bun run typecheck
 
 ## Resources
 
-- [Next.JS](https://nextjs.org/)
+- [Next.js](https://nextjs.org/)
 - [shadcn/ui](https://ui.shadcn.com/docs/registry)
 - [Fumadocs](https://fumadocs.dev/)
 


### PR DESCRIPTION
Fixed grammar and capitalization issues in README files:

- Changed "its" → Plural subject (two directories) requires plural possessive pronoun ("their").
- Fixed "Next.JS" → Official branding uses lowercase "js".