### PR TITLE
chore(coss-ui): fix import paths in sidebar

### DIFF
--- a/packages/ui/src/ui/sidebar.tsx
+++ b/packages/ui/src/ui/sidebar.tsx
@@ -2,6 +2,8 @@
 
 import { mergeProps } from "@base-ui-components/react/merge-props";
 import { useRender } from "@base-ui-components/react/use-render";
+import { useIsMobile } from "@coss/ui/hooks/use-mobile";
+import { cn } from "@coss/ui/lib/utils";
 import { Button } from "@coss/ui/ui/button";
 import { Input } from "@coss/ui/ui/input";
 import { Separator } from "@coss/ui/ui/separator";
@@ -14,8 +16,6 @@ import {
 } from "@coss/ui/ui/sheet";
 import { Skeleton } from "@coss/ui/ui/skeleton";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "@coss/ui/ui/tooltip";
-import { useIsMobile } from "@workspace/ui/hooks/use-mobile";
-import { cn } from "@workspace/ui/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 import { PanelLeftIcon } from "lucide-react";
 import * as React from "react";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated sidebar.tsx to import useIsMobile and cn from @coss/ui instead of @workspace/ui. This fixes module resolution errors and keeps the component aligned with the COSS UI package structure.

<sup>Written for commit 27b378b7babba535833731dd0015c4db9c0b0781. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

