### PR TITLE
fix: propagate:ui script

### DIFF
--- a/apps/ui/scripts/propagate-ui.mts
+++ b/apps/ui/scripts/propagate-ui.mts
@@ -68,6 +68,8 @@ function rewriteImports(code: string): string {
   // "@/lib/*"        → "@coss/ui/lib/*"
   // "@/hooks/*"      → "@coss/ui/hooks/*"
   // "@/registry/default/ui/*" → "@coss/ui/ui/*"
+  // "@/registry/default/hooks/*" → "@coss/ui/hooks/*"
+  // "@/registry/default/lib/*" → "@coss/ui/lib/*"
   result = result.replace(/(["'])@\/lib\//g, "$1@coss/ui/lib/");
   result = result.replace(/(["'])@\/hooks\//g, "$1@coss/ui/hooks/");
   result = result.replace(
@@ -76,11 +78,11 @@ function rewriteImports(code: string): string {
   );
   result = result.replace(
     /(["'])@\/registry\/default\/hooks\//g,
-    "$1@workspace/ui/hooks/",
+    "$1@coss/ui/hooks/",
   );
   result = result.replace(
     /(["'])@\/registry\/default\/lib\//g,
-    "$1@workspace/ui/lib/",
+    "$1@coss/ui/lib/",
   );
   return result;
 }

--- a/packages/ui/src/ui/sidebar.tsx
+++ b/packages/ui/src/ui/sidebar.tsx
@@ -2,6 +2,8 @@
 
 import { mergeProps } from "@base-ui-components/react/merge-props";
 import { useRender } from "@base-ui-components/react/use-render";
+import { useIsMobile } from "@coss/ui/hooks/use-mobile";
+import { cn } from "@coss/ui/lib/utils";
 import { Button } from "@coss/ui/ui/button";
 import { Input } from "@coss/ui/ui/input";
 import { Separator } from "@coss/ui/ui/separator";
@@ -14,8 +16,6 @@ import {
 } from "@coss/ui/ui/sheet";
 import { Skeleton } from "@coss/ui/ui/skeleton";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "@coss/ui/ui/tooltip";
-import { useIsMobile } from "@workspace/ui/hooks/use-mobile";
-import { cn } from "@workspace/ui/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 import { PanelLeftIcon } from "lucide-react";
 import * as React from "react";


### PR DESCRIPTION
…nents

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the propagate:ui script to correctly rewrite registry imports to @coss/ui, preventing wrong @workspace/ui paths. Also updates Sidebar imports to use @coss/ui for consistency.

<sup>Written for commit cb06a75a1f82f4461c8e81b4d59594aa48efcbb0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

