### PR TITLE
feat: improve particles page with category validation

### DIFF
--- a/apps/ui/app/particles/page.tsx
+++ b/apps/ui/app/particles/page.tsx
@@ -6,6 +6,8 @@ import {
 import type { Metadata } from "next";
 import { Suspense } from "react";
 
+import { isValidRegistryCategory } from "@/registry/registry-categories";
+
 import { ParticlesDisplay } from "./particles-display";
 import SearchContainer from "./search-container";
 
@@ -14,7 +16,7 @@ const description =
 
 export const metadata: Metadata = {
   description,
-  title: "Search components",
+  title: "Browse Particles - coss ui",
 };
 
 async function ParticlesDisplayServer({
@@ -23,11 +25,31 @@ async function ParticlesDisplayServer({
   searchParams: Promise<{ tags?: string }>;
 }) {
   const params = await searchParams;
-  const selectedCategories = params.tags?.split(",").filter(Boolean) || [];
+  const rawCategories = params.tags?.split(",").filter(Boolean) || [];
 
-  if (selectedCategories.length === 0) return null;
+  // Separate valid and invalid categories
+  const validCategories = rawCategories.filter((category) =>
+    isValidRegistryCategory(category),
+  );
+  const invalidCategories = rawCategories.filter(
+    (category) => !isValidRegistryCategory(category),
+  );
 
-  return <ParticlesDisplay selectedCategories={selectedCategories} />;
+  // If there are invalid categories, show "no components found" message
+  if (invalidCategories.length > 0) {
+    return (
+      <div className="text-center">
+        <p className="text-muted-foreground">
+          No particles found for the selected filters
+        </p>
+      </div>
+    );
+  }
+
+  // If no valid categories, don't render anything
+  if (validCategories.length === 0) return null;
+
+  return <ParticlesDisplay selectedCategories={validCategories} />;
 }
 
 export default function Page({

--- a/apps/ui/app/particles/particles-display.tsx
+++ b/apps/ui/app/particles/particles-display.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from "react";
+import { cache, Suspense } from "react";
 
 import { Index } from "@/registry/__index__";
 import { Skeleton } from "@/registry/default/ui/skeleton";
@@ -29,24 +29,27 @@ function ParticleCardSkeleton({ className }: { className?: string }) {
   );
 }
 
-export async function ParticlesDisplay({
-  selectedCategories,
-}: {
-  selectedCategories: string[];
-}) {
-  const particles = Object.values(Index).filter(
+// Cache the particles array to avoid recomputing on every render
+const getParticles = cache(() => {
+  return Object.values(Index).filter(
     (item) => item.type === "registry:block",
   ) as Array<{
     name: string;
     categories?: RegistryCategory[];
     meta?: { className?: string };
   }>;
+});
+
+export async function ParticlesDisplay({
+  selectedCategories,
+}: {
+  selectedCategories: RegistryCategory[];
+}) {
+  const particles = getParticles();
 
   const filteredParticles = particles.filter((particle) => {
     const categories = particle.categories ?? [];
-    return selectedCategories.every((value) =>
-      categories.includes(value as RegistryCategory),
-    );
+    return selectedCategories.every((value) => categories.includes(value));
   });
 
   if (filteredParticles.length === 0) {

--- a/apps/ui/registry/registry-categories.ts
+++ b/apps/ui/registry/registry-categories.ts
@@ -117,3 +117,10 @@ export function getCategorySortOrder(category: string): number {
   const index = categoryDisplayOrder.indexOf(category as RegistryCategory);
   return index === -1 ? Number.POSITIVE_INFINITY : index;
 }
+
+// Helper function to validate if a string is a valid RegistryCategory
+export function isValidRegistryCategory(
+  category: string,
+): category is RegistryCategory {
+  return registryCategories.includes(category as RegistryCategory);
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds category validation to the Particles page to ignore unknown tags and show a clear message when filters are invalid. Also updates the page title and caches the particle list for faster loads; aligns with Linear CUI-49.

- **New Features**
  - Validate tags with isValidRegistryCategory; show “No particles found for the selected filters” when any invalid tag is present.
  - If no valid categories remain, render nothing.
  - Update page title to “Browse Particles - coss ui”.

- **Refactors**
  - Cache the particle index with React cache() to avoid recomputing on each render.
  - Use RegistryCategory types end-to-end for safer filtering.

<sup>Written for commit c5691a524ee5c7e93fc491fe67e6cc26f95c5543. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

