### PR TITLE
fix: improve responsiveness of inline code block on homepage

### DIFF
--- a/apps/www/app/page.tsx
+++ b/apps/www/app/page.tsx
@@ -64,7 +64,7 @@ export default async function Page() {
         </p>
         <p className="leading-relaxed [&:not(:first-child)]:mt-6">
           for developers we are building the coss stack, a one line{" "}
-          <code className="before:-rotate-1 before:-z-10 relative z-10 px-[0.3rem] py-[0.2rem] font-mono text-primary-foreground text-sm outline-none before:pointer-events-none before:absolute before:inset-0 before:rounded-xs before:bg-primary">
+          <code className="before:-rotate-1 before:-z-10 relative z-10 inline-block px-[0.3rem] py-[0.2rem] font-mono text-primary-foreground text-sm outline-none before:pointer-events-none before:absolute before:inset-0 before:rounded-xs before:bg-primary">
             npm install @coss
           </code>{" "}
           package that includes everything you need to build your application,


### PR DESCRIPTION
## Summary

Added `inline-block` to the code element `className`. This ensures the code block behaves as an inline-block element, which allows it to wrap to a new line when there's not enough space, rather than overflowing.

> **Note:** _To reproduce, try resizing the screen and see `npm install @coss` disappearing._

**Before:**

<img width="580" height="189" alt="Screenshot from 2025-11-19 12-04-40" src="https://github.com/user-attachments/assets/ad140922-7720-4c4b-b0fa-7e43b112c393" />


**After:**

<img width="617" height="194" alt="Screenshot from 2025-11-19 12-04-34" src="https://github.com/user-attachments/assets/9259e804-7b04-42b9-ba02-c8245c348192" />
