### PR TITLE
refactor: remove redundant `copyToClipboard` function and use hook consistently

### DIFF
--- a/apps/ui/components/command-menu.tsx
+++ b/apps/ui/components/command-menu.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { copyToClipboard } from "@coss/ui/components/copy-button";
 import {
   ArrowTurnBackwardIcon,
   Atom01Icon,
@@ -25,6 +24,7 @@ import { useIsMac } from "@/hooks/use-is-mac";
 import { useMutationObserver } from "@/hooks/use-mutation-observer";
 import type { source } from "@/lib/source";
 import { cn } from "@/lib/utils";
+import { useCopyToClipboard } from "@/registry/default/hooks/use-copy-to-clipboard";
 import { Button } from "@/registry/default/ui/button";
 import {
   Dialog,
@@ -47,6 +47,7 @@ export function CommandMenu({
   const router = useRouter();
   const isMac = useIsMac();
   const [config] = useConfig();
+  const { copyToClipboard } = useCopyToClipboard();
   const [open, setOpen] = React.useState(false);
   const [selectedType, setSelectedType] = React.useState<
     "page" | "component" | null
@@ -116,7 +117,7 @@ export function CommandMenu({
 
     document.addEventListener("keydown", down);
     return () => document.removeEventListener("keydown", down);
-  }, [copyPayload, runCommand, selectedType]);
+  }, [copyPayload, runCommand, selectedType, copyToClipboard]);
 
   return (
     <Dialog onOpenChange={setOpen} open={open}>

--- a/apps/ui/components/copy-registry.tsx
+++ b/apps/ui/components/copy-registry.tsx
@@ -14,10 +14,6 @@ import {
   TooltipTrigger,
 } from "@/registry/default/ui/tooltip";
 
-export function copyToClipboard(value: string) {
-  navigator.clipboard.writeText(value);
-}
-
 export function CopyRegistry({
   value,
   className,

--- a/packages/ui/src/components/copy-button.tsx
+++ b/packages/ui/src/components/copy-button.tsx
@@ -8,10 +8,6 @@ import { Copy01Icon, Tick02Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type * as React from "react";
 
-export function copyToClipboard(value: string) {
-  navigator.clipboard.writeText(value);
-}
-
 export function CopyButton({
   value,
   className,


### PR DESCRIPTION
## Summary

This PR removes redundant `copyToClipboard` utility functions and refactors the code to use the `useCopyToClipboard` hook consistently across the codebase.