### PR TITLE
chore: add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# See http://EditorConfig.org for more information
+
+# top-most EditorConfig file
+root = true
+
+# Every File
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
I used the same configuration as the cal.com project: https://github.com/calcom/cal.com/blob/main/.editorconfig

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a project-wide .editorconfig to enforce consistent formatting across the repo. Settings: LF line endings, UTF-8 charset, final newline, trim trailing whitespace, 2-space indentation; Markdown files keep trailing whitespace.

<sup>Written for commit 84559655f09401bb1fb8f84b835cf48a76c3b77a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

