### PR TITLE
docs(menu): reference the right example

### DIFF
--- a/apps/ui/content/docs/components/menu.mdx
+++ b/apps/ui/content/docs/components/menu.mdx
@@ -156,7 +156,7 @@ import {
 
 ### Open a Dialog
 
-<ComponentPreview name="dialog-from-menu" />
+<ComponentPreview name="p-dialog-2" />
 
 ## Comparing with Radix / shadcn
 


### PR DESCRIPTION
Fixes:

<img width="933" height="293" alt="Screenshot 2025-11-28 at 10 25 51" src="https://github.com/user-attachments/assets/713ade0c-a179-4f1d-b577-71d543b37210" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Menu docs to point the “Open a Dialog” example to the correct preview (p-dialog-2), fixing the broken demo.

<sup>Written for commit ee26f2a9c6916ca5687632b31dc44b2985df7d66. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

