### PR TITLE
feat: add typecheck workflow for pull requests

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -30,4 +30,4 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Run typecheck
-        run: bun run type-check
+        run: bun run typecheck

--- a/apps/origin/package.json
+++ b/apps/origin/package.json
@@ -66,7 +66,7 @@
     "lint": "biome lint .",
     "registry:build": "shadcn build",
     "start": "next start",
-    "type-check": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "type": "module",
   "version": "0.1.0"

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -50,7 +50,7 @@
     "registry:build": "tsx --tsconfig ./tsconfig.scripts.json ./scripts/build-registry.mts",
     "registry:validate-deps": "tsx --tsconfig ./tsconfig.scripts.json ./scripts/validate-registry-deps.mts",
     "start": "next start --port 4000",
-    "type-check": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
     "ui:propagate": "tsx --tsconfig ./tsconfig.scripts.json ./scripts/propagate-ui.mts"
   },
   "type": "module",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -26,7 +26,7 @@
     "dev": "next dev",
     "lint": "biome lint .",
     "start": "next start",
-    "type-check": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "version": "0.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "turbo run lint --",
     "prepare": "husky",
     "test": "bun test --pass-with-no-tests",
-    "type-check": "turbo run type-check"
+    "typecheck": "turbo run typecheck"
   },
   "version": "0.0.1",
   "workspaces": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "clean": "rm -rf node_modules",
     "lint": "biome lint src",
-    "type-check": "tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "type": "module",
   "version": "0.0.0"

--- a/turbo.json
+++ b/turbo.json
@@ -18,9 +18,9 @@
       "cache": true,
       "dependsOn": ["^lint"]
     },
-    "type-check": {
+    "typecheck": {
       "cache": true,
-      "dependsOn": ["^type-check"]
+      "dependsOn": ["^typecheck"]
     }
   },
   "ui": "tui"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to run TypeScript type checking on pull requests. The workflow follows the existing patterns in the repo (same structure as lint.yml, build.yml, etc.) and integrates into the CI pipeline.

**Changes:**
- New `typecheck.yml` workflow using Bun and turbo (runs `bun run typecheck`)
- Updated `ci.yml` to include typecheck job (build now depends on it)
- Added `typecheck` task to `turbo.json` with caching
- Added `typecheck` script to root `package.json`
- Renamed `check-types` → `typecheck` in `apps/origin/package.json` for consistency
- Added `typecheck` script to `packages/ui/package.json`
- Excluded test files (`**/*.test.ts`, `**/*.test.tsx`) from `packages/ui/tsconfig.json` to avoid pre-existing type errors in test files that use `bun:test`

## Review & Testing Checklist for Human

- [ ] Verify the Typecheck workflow runs successfully on this PR's CI
- [ ] Review the tsconfig exclusion for test files in `packages/ui` - this was done because test files have pre-existing type errors with `bun:test` imports; verify this is acceptable (tests still run via `bun test`)
- [ ] Run `bun run typecheck` locally to confirm all 4 packages pass

### Notes

Tested locally with `bun run typecheck` - all 4 packages (www, ui, origin, @coss/ui) pass type checking.

The failing "Vercel – coss-com-origin" deployment appears to be an infrastructure issue unrelated to these changes (other Vercel deployments succeed).

**Link to Devin run:** https://app.devin.ai/sessions/428b2ba5c5be439b8f849ba61d6cad2c
**Requested by:** eunjae@cal.com (@eunjae-lee)