### PR TITLE
chore: specify bun version requirement in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "typescript": "^5.9.3"
   },
   "engines": {
-    "bun": ">=1.3"
+    "bun": ">=1.3.1"
   },
   "license": "AGPL-3.0-or-later",
   "name": "cosscom",


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Specify Bun >=1.3.1 in package.json engines and remove the Node requirement to enforce the supported runtime. This keeps local and CI environments consistent and prevents installs with older Bun versions.

<sup>Written for commit 7ecb44a84e6b5d40c53c7e58393a5d8b5c8b7d3f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



