### PR TITLE
chore: update bun.lock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cosscom",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Regenerated bun.lock to add configVersion: 0 so the lockfile matches the current Bun format and avoids tooling warnings. No code changes; this keeps installs reproducible and reduces future lockfile churn.

<sup>Written for commit fc83814e4e885a980fb3f83df55687e68f7d6437. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

