### PR TITLE
refactor(label): allow Label to receive a component via render

### DIFF
--- a/apps/ui/public/r/label.json
+++ b/apps/ui/public/r/label.json
@@ -5,7 +5,7 @@
   "files": [
     {
       "path": "registry/default/ui/label.tsx",
-      "content": "import type * as React from \"react\";\n\nimport { cn } from \"@/lib/utils\";\n\nfunction Label({ className, ...props }: React.ComponentProps<\"label\">) {\n  return (\n    <label\n      className={cn(\"inline-flex items-center gap-2 text-sm/4\", className)}\n      data-slot=\"label\"\n      {...props}\n    />\n  );\n}\n\nexport { Label };\n",
+      "content": "import { mergeProps } from \"@base-ui-components/react/merge-props\";\nimport { useRender } from \"@base-ui-components/react/use-render\";\n\nimport { cn } from \"@coss/ui/lib/utils\";\n\nfunction Label({\n  className,\n  render,\n  ...props\n}: useRender.ComponentProps<\"label\">) {\n  const defaultProps = {\n    className: cn(\"inline-flex items-center gap-2 text-sm/4\", className),\n    \"data-slot\": \"label\",\n  };\n\n  return useRender({\n    defaultTagName: \"label\",\n    props: mergeProps<\"label\">(defaultProps, props),\n    render,\n  });\n}\n\nexport { Label };\n",
       "type": "registry:ui"
     }
   ]

--- a/apps/ui/registry/default/ui/label.tsx
+++ b/apps/ui/registry/default/ui/label.tsx
@@ -1,15 +1,23 @@
-import type * as React from "react";
+import { mergeProps } from "@base-ui-components/react/merge-props";
+import { useRender } from "@base-ui-components/react/use-render";
 
-import { cn } from "@/lib/utils";
+import { cn } from "@coss/ui/lib/utils";
 
-function Label({ className, ...props }: React.ComponentProps<"label">) {
-  return (
-    <label
-      className={cn("inline-flex items-center gap-2 text-sm/4", className)}
-      data-slot="label"
-      {...props}
-    />
-  );
+function Label({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"label">) {
+  const defaultProps = {
+    className: cn("inline-flex items-center gap-2 text-sm/4", className),
+    "data-slot": "label",
+  };
+
+  return useRender({
+    defaultTagName: "label",
+    props: mergeProps<"label">(defaultProps, props),
+    render,
+  });
 }
 
 export { Label };

--- a/packages/ui/src/components/label.tsx
+++ b/packages/ui/src/components/label.tsx
@@ -1,15 +1,23 @@
-import type * as React from "react";
+import { mergeProps } from "@base-ui-components/react/merge-props";
+import { useRender } from "@base-ui-components/react/use-render";
 
 import { cn } from "@coss/ui/lib/utils";
 
-function Label({ className, ...props }: React.ComponentProps<"label">) {
-  return (
-    <label
-      className={cn("inline-flex items-center gap-2 text-sm/4", className)}
-      data-slot="label"
-      {...props}
-    />
-  );
+function Label({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"label">) {
+  const defaultProps = {
+    className: cn("inline-flex items-center gap-2 text-sm/4", className),
+    "data-slot": "label",
+  };
+
+  return useRender({
+    defaultTagName: "label",
+    props: mergeProps<"label">(defaultProps, props),
+    render,
+  });
 }
 
 export { Label };


### PR DESCRIPTION
Useful in case a user needs to render a different tag, like a FieldsetLegend

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored Label to accept a render prop so consumers can swap the underlying tag (e.g., FieldsetLegend) while keeping default styles and behavior. Addresses Linear CUI-81 by making Label more flexible without breaking existing usage.

- **New Features**
  - Integrated useRender with defaultTagName "label".
  - Merged default and user props via mergeProps; preserves className and data-slot.

<sup>Written for commit 807813dc55792912f9c866e887b3c54b09a8bb1a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

