### PR TITLE
chore: GitHub Action for proper PR titles

### DIFF
--- a/.github/workflows/semantic-pull-requests.yml
+++ b/.github/workflows/semantic-pull-requests.yml
@@ -1,0 +1,39 @@
+name: "Validate PRs"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  validate-pr:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        # When the previous steps fails, the workflow would stop. By adding this
+        # condition you can continue the execution with the populated error message.
+        if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        with:
+          header: pr-title-lint-error
+          message: |
+            Hey there and thank you for opening this pull request! 👋🏼
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a GitHub Action to enforce Conventional Commits PR titles and provide clear feedback when titles are invalid. Implements Linear CUI-97.

- **New Features**
  - Validates PR titles on open, reopen, edit, and sync using amannn/action-semantic-pull-request@v5.
  - Posts a sticky comment with the error details when validation fails (marocchino/sticky-pull-request-comment@v2).

<sup>Written for commit 6e05263a1defb9f0eadedda83ad6e3ab26c82a1c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

