### PR TITLE
Update import path for utility function 'cn'

### DIFF
--- a/packages/ui/src/components/spinner.tsx
+++ b/packages/ui/src/components/spinner.tsx
@@ -1,5 +1,6 @@
-import { cn } from "@coss/ui/lib/utils";
 import { Loader2Icon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
 
 function Spinner({
   className,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the Spinner component to import cn from "@/lib/utils" instead of "@coss/ui/lib/utils" to match our path alias and avoid resolution issues. No UI or functional changes.

<sup>Written for commit 6a3b5e27e079f3d42e4adee779e96293daed36ef. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

