### PR TITLE
fix(docs): correct particle name in toggle-group with-tooltips demo

### DIFF
--- a/apps/ui/content/docs/components/toggle-group.mdx
+++ b/apps/ui/content/docs/components/toggle-group.mdx
@@ -89,4 +89,4 @@ import { Toggle, ToggleGroup } from "@/components/ui/toggle-group"
 
 ### With Tooltips
 
-<ComponentPreview name="tooltip-grouped" />
+<ComponentPreview name="p-toggle-group-9" />


### PR DESCRIPTION
### What changed
- Fixed incorrect particle name in `toggle-group.mdx` for the **With Tooltips** demo

### Before
<img width="822" height="157" alt="image" src="https://github.com/user-attachments/assets/f46f347d-bdfc-4a85-93bb-640505204a05" />

### After
<img width="822" height="678" alt="image" src="https://github.com/user-attachments/assets/e09e75ed-557b-4360-85fe-46f1531bc3fe" />

