### PR TITLE
docs: add Figma community file to resources

### DIFF
--- a/apps/ui/content/docs/resources/figma.mdx
+++ b/apps/ui/content/docs/resources/figma.mdx
@@ -1,0 +1,16 @@
+---
+title: Figma Community File
+description: An unofficial community Figma file for the coss.com ui.
+---
+
+This file is maintained by the community and is a great starting point for designing with coss ui components with TailwindCSS variables in Figma.
+
+<Alert className="bg-muted/24">
+  <InfoIcon />
+  <AlertTitle>Community resource</AlertTitle>
+  <AlertDescription>
+    This is an unofficial file created and maintained by the community, and may not be consistently maintained.
+  </AlertDescription>
+</Alert>
+
+<Button render={<Link href="https://www.figma.com/community/file/1599506644197878123/" target="_blank" rel="noopener noreferrer" className="no-underline!" style={{ textDecoration: 'none' }} />}>Open Figma community file</Button>

--- a/apps/ui/content/docs/resources/meta.json
+++ b/apps/ui/content/docs/resources/meta.json
@@ -1,7 +1,8 @@
 {
   "pages": [
     "[llms.txt](/llms.txt)",
-    "[coss.com origin](https://coss.com/origin)"
+    "[coss.com origin](https://coss.com/origin)",
+    "figma"
   ],
   "title": "Resources"
 }


### PR DESCRIPTION
**Add Figma community design file**

Adds a link to an unofficial community Figma file ([COSS Design System – TailwindCSS + BaseUI](https://www.figma.com/community/file/1599506644197878123/coss-design-system-tailwindcss-baseui)) under the Resources section in the docs sidebar.
Includes:
- New [figma.mdx](cci:7://file:///d:/coss/apps/ui/content/docs/resources/figma.mdx:0:0-0:0) page with official "no support" disclaimer
- Sidebar entry under Resources
- CTA button linking to the Figma file