### PR TITLE
feat: add sitemaps for all apps and robots.txt at root

### DIFF
--- a/apps/origin/app/robots.txt
+++ b/apps/origin/app/robots.txt
@@ -1,5 +1,0 @@
-User-Agent: *
-Allow: /
-Disallow: /private/
-
-Sitemap: https://coss.com/origin/sitemap.xml

--- a/apps/ui/app/sitemap.ts
+++ b/apps/ui/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+import { source } from "@/lib/source";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const pages = source.getPages();
+
+  return [
+    { url: "https://coss.com/ui" },
+    { url: "https://coss.com/ui/particles" },
+    ...pages.map((page) => ({
+      url: `https://coss.com/ui${page.url}`,
+    })),
+  ];
+}

--- a/apps/www/app/robots.ts
+++ b/apps/www/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      allow: "/",
+      disallow: "/private/",
+      userAgent: "*",
+    },
+    sitemap: [
+      "https://coss.com/sitemap.xml",
+      "https://coss.com/origin/sitemap.xml",
+      "https://coss.com/ui/sitemap.xml",
+    ],
+  };
+}

--- a/apps/www/app/sitemap.ts
+++ b/apps/www/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    { url: "https://coss.com" },
+    { url: "https://coss.com/scheduling" },
+    { url: "https://coss.com/calendar" },
+    { url: "https://coss.com/email" },
+    { url: "https://coss.com/sms" },
+    { url: "https://coss.com/video" },
+    { url: "https://coss.com/payments" },
+    { url: "https://coss.com/notifications" },
+    { url: "https://coss.com/auth" },
+  ];
+}


### PR DESCRIPTION
## Summary

Adds per-app sitemaps for the `www` and `ui` apps (the `origin` app already had one), and moves the canonical `robots.txt` to the `www` app so it serves at `coss.com/robots.txt` with references to all three sitemaps.

**Changes:**
- **`apps/www/app/sitemap.ts`** — Static sitemap listing all www pages (home, scheduling, calendar, email, sms, video, payments, notifications, auth)
- **`apps/www/app/robots.ts`** — Programmatic robots.txt that references all three app sitemaps (`/sitemap.xml`, `/origin/sitemap.xml`, `/ui/sitemap.xml`)
- **`apps/ui/app/sitemap.ts`** — Dynamic sitemap using fumadocs `source.getPages()` for all doc pages, plus the home and particles pages
- **Deleted `apps/origin/app/robots.txt`** — Was serving at `/origin/robots.txt` (due to basePath), not at the root domain, so was effectively invisible to crawlers

## Review & Testing Checklist for Human

- [ ] **Verify `ui` sitemap URL format**: `source.getPages()` returns pages with a `.url` property (e.g. `/docs`, `/docs/components/button`). Confirm that `https://coss.com/ui${page.url}` produces correct URLs (no missing `/` separator). Deploy preview or local build of the `ui` app and check `/ui/sitemap.xml` output.
- [ ] **Verify `www` sitemap page list is complete**: The static list was based on the current `apps/www/app/` directory. Confirm no pages are missing. Note: if new pages are added to `www` in the future, this file needs to be manually updated.
- [ ] **Test all three sitemaps after deploy**: Hit `coss.com/sitemap.xml`, `coss.com/origin/sitemap.xml`, `coss.com/ui/sitemap.xml` and verify valid XML output. Also verify `coss.com/robots.txt` lists all three.

### Notes
- The `www` sitemap is a static list — consider whether this should be dynamic in the future if pages are added frequently.
- The old `origin/app/robots.txt` `Disallow: /private/` rule was preserved in the new root `robots.ts`.
- Requested by: @pasqualevitiello
- [Link to Devin run](https://app.devin.ai/sessions/0c19e2975cb0459dadb7790b25cff6e8)