### PR TITLE
fix: update coss/style command

### DIFF
--- a/apps/ui/content/docs/(root)/get-started.mdx
+++ b/apps/ui/content/docs/(root)/get-started.mdx
@@ -22,7 +22,7 @@ Each component page provides a command to add it to your project automatically. 
 For new projects, use the **coss style** preset to initialize everything in one command:
 
 ```bash
-npx shadcn@latest init coss/style
+npx shadcn@latest init @coss/style
 ```
 
 This installs all UI components, the neutral color system, sidebar variables, font variables, and base styles. Components like Dialog and AlertDialog use `font-heading` for titles—the style preset provides sensible fallbacks, and you can customize fonts via `next/font` in your layout.

--- a/apps/ui/public/r/registry.json
+++ b/apps/ui/public/r/registry.json
@@ -10415,7 +10415,7 @@
         "class-variance-authority",
         "lucide-react"
       ],
-      "description": "Complete coss theme: colors, sidebar, fonts, and base styles. Use with `npx shadcn init coss/style` for full project setup.",
+      "description": "Complete coss theme: colors, sidebar, fonts, and base styles. Use with `npx shadcn init @coss/style` for full project setup.",
       "devDependencies": [
         "tw-animate-css"
       ],

--- a/apps/ui/public/r/style.json
+++ b/apps/ui/public/r/style.json
@@ -3,7 +3,7 @@
   "extends": "none",
   "name": "style",
   "type": "registry:style",
-  "description": "Complete coss theme: colors, sidebar, fonts, and base styles. Use with `npx shadcn init coss/style` for full project setup.",
+  "description": "Complete coss theme: colors, sidebar, fonts, and base styles. Use with `npx shadcn init @coss/style` for full project setup.",
   "dependencies": [
     "@base-ui/react",
     "class-variance-authority",

--- a/apps/ui/registry.json
+++ b/apps/ui/registry.json
@@ -10415,7 +10415,7 @@
         "class-variance-authority",
         "lucide-react"
       ],
-      "description": "Complete coss theme: colors, sidebar, fonts, and base styles. Use with `npx shadcn init coss/style` for full project setup.",
+      "description": "Complete coss theme: colors, sidebar, fonts, and base styles. Use with `npx shadcn init @coss/style` for full project setup.",
       "devDependencies": [
         "tw-animate-css"
       ],

--- a/apps/ui/registry/registry-styles.ts
+++ b/apps/ui/registry/registry-styles.ts
@@ -131,7 +131,7 @@ export const styles: Registry["items"] = [
       "lucide-react",
     ],
     description:
-      "Complete coss theme: colors, sidebar, fonts, and base styles. Use with `npx shadcn init coss/style` for full project setup.",
+      "Complete coss theme: colors, sidebar, fonts, and base styles. Use with `npx shadcn init @coss/style` for full project setup.",
     devDependencies: ["tw-animate-css"],
     extends: "none",
     name: "style",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the style preset command by switching from coss/style to the scoped package: npx shadcn@latest init @coss/style. Updated docs and registry descriptions to reference the correct command (CUI-141).

<sup>Written for commit a8e0f396c90b0d49b79d02bc9b374905475ae82b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

