### PR TITLE
docs: add Figma community file to resources

### DIFF
--- a/apps/ui/content/docs/resources/figma.mdx
+++ b/apps/ui/content/docs/resources/figma.mdx
@@ -1,0 +1,16 @@
+---
+title: Figma Community File
+description: An unofficial community Figma file for the coss.com ui.
+---
+
+This file is maintained by the community and is a great starting point for designing with coss ui components with TailwindCSS variables in Figma.
+
+<Alert className="bg-muted/24">
+  <InfoIcon />
+  <AlertTitle>Community resource</AlertTitle>
+  <AlertDescription>
+    This is an unofficial file created and maintained by the community, and may not be consistently maintained.
+  </AlertDescription>
+</Alert>
+
+<Button render={<Link href="https://www.figma.com/community/file/1599506644197878123/" target="_blank" rel="noopener noreferrer" className="no-underline!" style={{ textDecoration: 'none' }} />}>Open Figma community file</Button>

--- a/apps/ui/content/docs/resources/meta.json
+++ b/apps/ui/content/docs/resources/meta.json
@@ -1,7 +1,8 @@
 {
   "pages": [
     "[llms.txt](/llms.txt)",
-    "[coss.com origin](https://coss.com/origin)"
+    "[coss.com origin](https://coss.com/origin)",
+    "figma"
   ],
   "title": "Resources"
 }


### PR DESCRIPTION
Follow-up to #698 (closed after review).

Adds a link to an unofficial community Figma file ([coss ui – TailwindCSS + BaseUI](https://www.figma.com/community/file/1599506644197878123/)) under the Resources section in the docs sidebar.

**Includes:**
- New `figma.mdx` page with community disclaimer
- Sidebar entry under Resources
- CTA button linking to the Figma file

### Changes since #698 review

Based on @pasqualevitiello's feedback, the Figma file itself has been overhauled to better match production:

- **Icon opacity:** Fixed all icon opacities — button icons now correctly set to 80%.
- **Shadows:** Refactored to use stacked shadows matching the production popovers and other components.
- **Inputs & disabled states:** Refactored to better reflect the codebase.
- **Responsive sizing:** Updated mobile and desktop sizing logic for Checkboxes and Radio Groups for 1:1 parity with the live site.
- **Community disclaimer:** Added a prominent warning within the Figma file clarifying this is a solo community project and the GitHub repo remains the source of truth, with an invitation for users to report discrepancies via Figma community comments or email so it can be kept up to date.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cosscom/coss/pull/750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
