### PR TITLE
chore: Remove ProductsDropdown from SiteHeader

### DIFF
--- a/packages/ui/src/shared/site-header.tsx
+++ b/packages/ui/src/shared/site-header.tsx
@@ -2,7 +2,6 @@ import { siteConfig } from "@coss/ui/lib/config";
 import { GitHubLink } from "@coss/ui/shared/github-link";
 import { ModeSwitcher } from "@coss/ui/shared/mode-switcher";
 import { ProductLabel } from "@coss/ui/shared/product-label";
-import { ProductsDropdown } from "@coss/ui/shared/products-dropdown";
 import Link from "next/link";
 
 export function SiteHeader({
@@ -39,7 +38,6 @@ export function SiteHeader({
         </div>
         <div className="ms-auto flex items-center gap-2 md:flex-1 md:justify-end">
           {children}
-          <ProductsDropdown items={siteConfig.products} />
           <GitHubLink />
           <ModeSwitcher />
         </div>


### PR DESCRIPTION
Removed ProductsDropdown component from SiteHeader.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cosscom/coss/pull/772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->