### PR TITLE
fix(alert-dialog): export AlertDialogPanel

### DIFF
--- a/apps/ui/registry/default/ui/alert-dialog.tsx
+++ b/apps/ui/registry/default/ui/alert-dialog.tsx
@@ -164,4 +164,5 @@ export {
   AlertDialogPrimitive,
   AlertDialogBackdrop as AlertDialogOverlay,
   AlertDialogPopup as AlertDialogContent,
+  AlertDialogPopup as AlertDialogPanel,
 };

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cosscom",

--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -164,4 +164,5 @@ export {
   AlertDialogPrimitive,
   AlertDialogBackdrop as AlertDialogOverlay,
   AlertDialogPopup as AlertDialogContent,
+  AlertDialogPopup as AlertDialogPanel,
 };


### PR DESCRIPTION
Closes #775

`AlertDialogPanel` was missing from the exports. Added it as an alias for `AlertDialogPopup`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cosscom/coss/pull/776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->