### PR TITLE
docs(skills): refresh particle references

### DIFF
--- a/apps/ui/skills/coss-particles/SKILL.md
+++ b/apps/ui/skills/coss-particles/SKILL.md
@@ -37,25 +37,26 @@ Run the generator script from the coss repo root:
 node apps/ui/scripts/generate-particle-index.cjs
 ```
 
-Total: **484 particles** across **52 component types**
+Total: **500 particles** across **53 component types**
 
 ## Component types
 
 - [accordion](#accordion) (4)
 - [alert](#alert) (7)
 - [alert-dialog](#alert-dialog) (2)
-- [autocomplete](#autocomplete) (15)
+- [autocomplete](#autocomplete) (16)
 - [avatar](#avatar) (14)
 - [badge](#badge) (20)
 - [breadcrumb](#breadcrumb) (7)
 - [button](#button) (40)
-- [calendar](#calendar) (24)
+- [calendar](#calendar) (25)
 - [card](#card) (11)
 - [checkbox](#checkbox) (5)
 - [checkbox-group](#checkbox-group) (5)
 - [collapsible](#collapsible) (1)
-- [combobox](#combobox) (18)
+- [combobox](#combobox) (20)
 - [command](#command) (2)
+- [context-menu](#context-menu) (8)
 - [date-picker](#date-picker) (9)
 - [dialog](#dialog) (6)
 - [drawer](#drawer) (14)
@@ -73,7 +74,7 @@ Total: **484 particles** across **52 component types**
 - [number-field](#number-field) (11)
 - [otp-field](#otp-field) (9)
 - [pagination](#pagination) (3)
-- [popover](#popover) (3)
+- [popover](#popover) (4)
 - [preview-card](#preview-card) (1)
 - [progress](#progress) (3)
 - [radio-group](#radio-group) (6)
@@ -84,7 +85,7 @@ Total: **484 particles** across **52 component types**
 - [skeleton](#skeleton) (2)
 - [slider](#slider) (23)
 - [spinner](#spinner) (1)
-- [switch](#switch) (6)
+- [switch](#switch) (9)
 - [table](#table) (8)
 - [tabs](#tabs) (13)
 - [textarea](#textarea) (15)
@@ -135,6 +136,7 @@ Total: **484 particles** across **52 component types**
 - Autocomplete form | [JSON](https://coss.com/ui/r/p-autocomplete-13.json)
 - Autocomplete form | [JSON](https://coss.com/ui/r/p-autocomplete-14.json)
 - Pill-shaped autocomplete | [JSON](https://coss.com/ui/r/p-autocomplete-15.json)
+- Address autocomplete with Google Maps Places API | [JSON](https://coss.com/ui/r/p-autocomplete-16.json)
 
 ### avatar
 
@@ -255,6 +257,7 @@ Total: **484 particles** across **52 component types**
 - Two months calendar | [JSON](https://coss.com/ui/r/p-calendar-22.json)
 - Three months calendar | [JSON](https://coss.com/ui/r/p-calendar-23.json)
 - Pricing calendar with custom day buttons | [JSON](https://coss.com/ui/r/p-calendar-24.json)
+- Calendar with 24-hour autocomplete time input | [JSON](https://coss.com/ui/r/p-calendar-25.json)
 
 ### card
 
@@ -310,11 +313,24 @@ Total: **484 particles** across **52 component types**
 - Timezone combobox | [JSON](https://coss.com/ui/r/p-combobox-16.json)
 - Timezone combobox with search input | [JSON](https://coss.com/ui/r/p-combobox-17.json)
 - Combobox with select trigger | [JSON](https://coss.com/ui/r/p-combobox-18.json)
+- Combobox multiple with stacked chips | [JSON](https://coss.com/ui/r/p-combobox-19.json)
+- Combobox multiple with stacked divided chips | [JSON](https://coss.com/ui/r/p-combobox-20.json)
 
 ### command
 
 - Command palette with dialog | [JSON](https://coss.com/ui/r/p-command-1.json)
 - Command palette with AI assistant | [JSON](https://coss.com/ui/r/p-command-2.json)
+
+### context-menu
+
+- Basic context menu | [JSON](https://coss.com/ui/r/p-context-menu-1.json)
+- Context menu with link items | [JSON](https://coss.com/ui/r/p-context-menu-2.json)
+- Nested context menu | [JSON](https://coss.com/ui/r/p-context-menu-3.json)
+- Context menu with checkbox items | [JSON](https://coss.com/ui/r/p-context-menu-4.json)
+- Context menu with group labels | [JSON](https://coss.com/ui/r/p-context-menu-5.json)
+- Context menu with icons | [JSON](https://coss.com/ui/r/p-context-menu-6.json)
+- Context menu with radio group | [JSON](https://coss.com/ui/r/p-context-menu-7.json)
+- Context menu with switch checkbox items | [JSON](https://coss.com/ui/r/p-context-menu-8.json)
 
 ### date-picker
 
@@ -533,6 +549,7 @@ Total: **484 particles** across **52 component types**
 - Popover with a form | [JSON](https://coss.com/ui/r/p-popover-1.json)
 - Popover with close button | [JSON](https://coss.com/ui/r/p-popover-2.json)
 - Animated popovers | [JSON](https://coss.com/ui/r/p-popover-3.json)
+- Split button with popover to confirm multiple occurrences | [JSON](https://coss.com/ui/r/p-popover-4.json)
 
 ### preview-card
 
@@ -640,6 +657,9 @@ Total: **484 particles** across **52 component types**
 - Switch card | [JSON](https://coss.com/ui/r/p-switch-4.json)
 - Switch in form | [JSON](https://coss.com/ui/r/p-switch-5.json)
 - Custom size switch | [JSON](https://coss.com/ui/r/p-switch-6.json)
+- Weekly availability editor with time range combobox pickers | [JSON](https://coss.com/ui/r/p-switch-7.json)
+- Weekly availability editor with grouped time range controls | [JSON](https://coss.com/ui/r/p-switch-8.json)
+- Weekly availability editor with From/To labeled time groups | [JSON](https://coss.com/ui/r/p-switch-9.json)
 
 ### table
 

--- a/apps/ui/skills/coss/references/primitives/autocomplete.md
+++ b/apps/ui/skills/coss/references/primitives/autocomplete.md
@@ -112,7 +112,7 @@ Form integration: place `Autocomplete` inside `Field name="..."` with `FieldLabe
 
 ### More examples
 
-See `p-autocomplete-1` through `p-autocomplete-15` for sizes, matching behavior, groups, limited results, async, form integration, and pill input patterns.
+See `p-autocomplete-1` through `p-autocomplete-16` for sizes, matching behavior, groups, limited results, async integrations, forms, and pill input patterns.
 
 ## Common pitfalls
 
@@ -121,6 +121,7 @@ See `p-autocomplete-1` through `p-autocomplete-15` for sizes, matching behavior,
 - Mixing combobox/select assumptions into autocomplete APIs without checking docs.
 - Missing explicit labels (`FieldLabel` or `aria-label`) on the input.
 - Not handling async race/error states (`loading`, `error`, stale response cancellation).
+- Exposing an unrestricted browser API key in an external address integration; apply provider restrictions and cancel stale requests.
 
 ## Useful particle references
 
@@ -132,3 +133,4 @@ See `p-autocomplete-1` through `p-autocomplete-15` for sizes, matching behavior,
 - async search with loading/error status: `p-autocomplete-12`
 - form integration: `p-autocomplete-13`
 - style variant (pill input): `p-autocomplete-15`
+- Google Maps Places address suggestions with debouncing, cancellation, status feedback, and session tokens: `p-autocomplete-16`

--- a/apps/ui/skills/coss/references/primitives/calendar.md
+++ b/apps/ui/skills/coss/references/primitives/calendar.md
@@ -66,3 +66,4 @@ See `p-calendar-1` through `p-calendar-6` for single, range, dropdown navigation
 - dropdown navigation: `p-calendar-4`
 - select dropdown for month/year: `p-calendar-5`
 - combobox dropdown for month/year: `p-calendar-6`
+- date plus a validated 24-hour autocomplete time input: `p-calendar-25`

--- a/apps/ui/skills/coss/references/primitives/combobox.md
+++ b/apps/ui/skills/coss/references/primitives/combobox.md
@@ -111,4 +111,6 @@ See `p-combobox-1` through `p-combobox-9` for sizes, label, auto-highlight, clea
 - with clear button: `p-combobox-7`
 - with groups: `p-combobox-8`
 - with multiple selection: `p-combobox-9`
+- multiple team selection rendered as separate stacked rows: `p-combobox-19`
+- multiple team selection rendered as a divided stack: `p-combobox-20`
 - related search/selection references: `p-autocomplete-1`, `p-select-1`, `p-input-group-1`

--- a/apps/ui/skills/coss/references/primitives/popover.md
+++ b/apps/ui/skills/coss/references/primitives/popover.md
@@ -72,4 +72,5 @@ import {
 - baseline popover with form content: `p-popover-1`
 - close controls (icon + action button): `p-popover-2`
 - detached trigger handle pattern: `p-popover-3`
+- split-button confirmation flow with selectable occurrences: `p-popover-4`
 - tooltip-style popover usage example: `p-input-group-7`

--- a/apps/ui/skills/coss/references/primitives/switch.md
+++ b/apps/ui/skills/coss/references/primitives/switch.md
@@ -74,6 +74,7 @@ Disabled switch:
 - customizing size: `p-switch-6`
 - card style: `p-switch-4`
 - form integration: `p-switch-5`
+- weekly availability editors with searchable time ranges: `p-switch-7`, `p-switch-8`, `p-switch-9`
 
 ## Common pitfalls
 
@@ -83,4 +84,4 @@ Disabled switch:
 
 ## Useful particle references
 
-See `p-switch-1` through `p-switch-6` for label, disabled, description, card, form, and size patterns.
+See `p-switch-1` through `p-switch-6` for label, disabled, description, card, form, and size patterns. See `p-switch-7` through `p-switch-9` for complete weekly availability editors using Switch, Combobox, Popover, and grouped controls.


### PR DESCRIPTION
## Summary
- regenerate the COSS particle skill so all 500 registry particles are indexed
- add new Autocomplete, Calendar, Combobox, Popover, and Switch patterns to their primitive guides
- document browser API-key restrictions and stale-request cancellation for external address autocomplete

## Validation
- regenerated the particle index twice to verify deterministic output
- verified exact one-to-one parity between all 500 registry particles and skill entries
- validated both skill frontmatter files and checked for unfinished placeholders
- ran repository formatting and diff checks