### PR TITLE
chore(ui): define Tailwind CSS compatibility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -200,6 +200,7 @@
       "peerDependencies": {
         "next": "^16.2.5",
         "react": "^19.2.6",
+        "tailwindcss": ">=4.1.17 <5",
       },
     },
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,7 +39,8 @@
   "name": "@coss/ui",
   "peerDependencies": {
     "next": "^16.2.5",
-    "react": "^19.2.6"
+    "react": "^19.2.6",
+    "tailwindcss": ">=4.1.17 <5"
   },
   "scripts": {
     "clean": "rm -rf node_modules",


### PR DESCRIPTION
## Summary

- add Tailwind CSS as a peer dependency of `@coss/ui`
- support Tailwind CSS versions `>=4.1.17 <5`

## Why

coss components are compiled by the consuming application and already use features introduced in Tailwind CSS 4.1. Declaring the supported range allows package managers to surface incompatible Tailwind versions instead of letting unsupported utilities silently produce no CSS.

## Testing

- `bunx biome check packages/ui/package.json`
- `bun install --frozen-lockfile`
